### PR TITLE
Fix bug in build task allowing it to run multiple times when multitargeting and when packing nuget packages.

### DIFF
--- a/build/GitBuildInfo.SourceGenerator.props
+++ b/build/GitBuildInfo.SourceGenerator.props
@@ -1,4 +1,4 @@
-<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project>
 
   <PropertyGroup>
     <GitBuildInfoIsGeneric Condition="'$(GitBuildInfoIsGeneric)' == ''">false</GitBuildInfoIsGeneric>

--- a/build/GitBuildInfo.SourceGenerator.targets
+++ b/build/GitBuildInfo.SourceGenerator.targets
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project>
 
   <UsingTask TaskName="GitBuildInfo.GitInfoTask"
              TaskFactory="RoslynCodeTaskFactory"
@@ -15,7 +14,7 @@
     </Task>
   </UsingTask>
 
-  <Target Name="GitBuildInfo" AfterTargets="PrepareForBuild">
+  <Target Name="GitBuildInfo" AfterTargets="BeforeBuild">
     <GitInfoTask ProjectDir="$(MSBuildProjectDirectory)">
       <Output TaskParameter="GitHead" PropertyName="GitHead" />
       <Output TaskParameter="CommitHash" PropertyName="CommitHash" />

--- a/src/Elskom.GitInformation/stylecop.json
+++ b/src/Elskom.GitInformation/stylecop.json
@@ -7,6 +7,9 @@
 
   "$schema": "https://raw.githubusercontent.com/DotNetAnalyzers/StyleCopAnalyzers/master/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json",
   "settings": {
+    "layoutRules": {
+      "newlineAtEndOfFile": "require"
+    },
     "documentationRules": {
       "companyName": "Els_kom org.",
       "copyrightText": "Copyright (c) 2019-2021, {companyName}\nhttps://github.com/Elskom/\nAll rights reserved.\nlicense: MIT, see LICENSE for more details.",

--- a/src/GitBuildInfo.SourceGenerator/Directory.Build.props
+++ b/src/GitBuildInfo.SourceGenerator/Directory.Build.props
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <IsPackable>true</IsPackable>
-    <Version>1.0.11</Version>
-    <PackageReleaseNotes>Fix bug in build task treating MSBuildProjectDirectory as MSBuildProjectFullPath.</PackageReleaseNotes>
+    <Version>1.0.12</Version>
+    <PackageReleaseNotes>Fix bug in build task allowing it to run multiple times when multitargeting and when packing nuget packages.</PackageReleaseNotes>
     <Copyright>Copyright (c) 2021</Copyright>
     <!-- Special properties for analyzer packages. -->
     <IncludeBuildOutput>false</IncludeBuildOutput>


### PR DESCRIPTION

# Checklist

- [x] I have read the Code of Conduct and the Contributing files before opening this issue.
- [x] I have verified the issue this pull request fixes or feature this pull request implements is to the current release.
- [x] I am using the latest stable release with the above code fix or the current main branch if code changes are present (prerelease code changes).
- [x] I have debugged and tested my changes before submitting this issue and that everything should just work.

## Describe the issue this fixes / feature this adds

<!-- A brief description of what this fixes or what this adds should be here. -->
