### PR TITLE
Fixed bug in GitInformation.IsTag where it will never be true even when it should be.

### DIFF
--- a/src/Elskom.GitInformation/Directory.Build.props
+++ b/src/Elskom.GitInformation/Directory.Build.props
@@ -6,8 +6,8 @@
     <PackageTags>GitBuildInformation</PackageTags>
     <Copyright>Copyright (c) 2019-2021</Copyright>
     <Description>A c# library that Registers git repository information on the assembly.</Description>
-    <PackageReleaseNotes>Initial Release.</PackageReleaseNotes>
-    <Version>1.0.0</Version>
+    <PackageReleaseNotes>Fixed bug in GitInformation.IsTag where it will never be true even when it should be.</PackageReleaseNotes>
+    <Version>1.0.1</Version>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <NeutralLanguage>en-US</NeutralLanguage>
     <NoWarn>$(NoWarn);NU5104;NU5118</NoWarn>

--- a/src/Elskom.GitInformation/GitInformation.cs
+++ b/src/Elskom.GitInformation/GitInformation.cs
@@ -90,7 +90,7 @@ namespace Elskom.Generic.Libs
         /// <value>
         /// A value indicating whether refs point to a stable tag release.
         /// </value>
-        public bool IsTag => this.Headdesc.StartsWith("refs/tags", StringComparison.Ordinal);
+        public bool IsTag => this.Headdesc.StartsWith("tags/", StringComparison.Ordinal);
 
         /// <summary>
         /// Applies the <see cref="Attribute"/>s that the specified <see cref="Assembly"/> contains.


### PR DESCRIPTION
# Checklist

- [x] I have read the Code of Conduct and the Contributing files before opening this issue.
- [x] I have verified the issue this pull request fixes or feature this pull request implements is to the current release.
- [x] I am using the latest stable release with the above code fix or the current main branch if code changes are present (prerelease code changes).
- [x] I have debugged and tested my changes before submitting this issue and that everything should just work.

## Describe the issue this fixes / feature this adds

<!-- A brief description of what this fixes or what this adds should be here. -->
